### PR TITLE
Archaic

### DIFF
--- a/EGMapEditor/DockContent/MapController.cs
+++ b/EGMapEditor/DockContent/MapController.cs
@@ -157,11 +157,11 @@ namespace EGMapEditor
                     {
                         if (Map.Tiles[l][y * Map.Width + x].Tileset >= 0 && Map.Tiles[l][y * Map.Width + x].Id >= 0)
                         {
-                            _tempSprite = new Sprite(MapEditor.Instance.Tilesets[Map.Tiles[l][y*Map.Width + x].Tileset])
+                            _tempSprite = new Sprite(MapEditor.Instance.Tilesets[Map.Tiles[l][y * Map.Width + x].Tileset])
                             {
-                                Position = new Vector2f(x*tempx, y*tempy)
+                                Position = new Vector2f(x * tempx, y * tempy)
                             };
-                            _tempSprite.TextureRect = new IntRect(Map.Tiles[l][y * Map.Width + x].Id % (int)(_tempSprite.Texture.Size.X / tempx) * tempx, 
+                            _tempSprite.TextureRect = new IntRect(Map.Tiles[l][y * Map.Width + x].Id % (int)(_tempSprite.Texture.Size.X / tempx) * tempx,
                                 Map.Tiles[l][y * Map.Width + x].Id / (int)(_tempSprite.Texture.Size.X / tempx) * tempy, tempx, tempy);
                             mapViewer.Draw(_tempSprite);
                         }
@@ -173,24 +173,25 @@ namespace EGMapEditor
                 foreach (Vertex[] v in _lines)
                     mapViewer.RenderSurface.Draw(v, PrimitiveType.Lines); // Because i forgot to include Draw Overloads.
 
-            foreach (SelectedTileArea st in MapEditor.Instance.SelectingArea)
-            {
-                int mouseY = (Mouse.GetPosition(mapViewer.RenderSurface).Y + _offsetY) / tempy;
-                int mouseX = (Mouse.GetPosition(mapViewer.RenderSurface).X + _offsetX) / tempx;
-
-                _tempSprite = new Sprite(MapEditor.Instance.Tilesets[st.Tileset])
+            if (MapEditor.Instance.CurrentFocusedMap == this)
+                foreach (SelectedTileArea st in MapEditor.Instance.SelectingArea)
                 {
-                    Position = new Vector2f((mouseX + st.OffsetX)*tempx, (mouseY + st.OffsetY)*tempy)
-                };
+                    int mouseY = (Mouse.GetPosition(mapViewer.RenderSurface).Y + _offsetY) / tempy;
+                    int mouseX = (Mouse.GetPosition(mapViewer.RenderSurface).X + _offsetX) / tempx;
 
-                _tempSprite.TextureRect = new IntRect(st.Id % (int)(_tempSprite.Texture.Size.X / tempx) * tempx,
-                    st.Id / (int)(_tempSprite.Texture.Size.X / tempx) * tempy, tempx, tempy);
+                    _tempSprite = new Sprite(MapEditor.Instance.Tilesets[st.Tileset])
+                    {
+                        Position = new Vector2f((mouseX + st.OffsetX) * tempx, (mouseY + st.OffsetY) * tempy)
+                    };
+
+                    _tempSprite.TextureRect = new IntRect(st.Id % (int)(_tempSprite.Texture.Size.X / tempx) * tempx,
+                        st.Id / (int)(_tempSprite.Texture.Size.X / tempx) * tempy, tempx, tempy);
 
 
-                var c = _tempSprite.Color;
-                _tempSprite.Color = new Color(c.R, c.G, c.B, 128);
-                mapViewer.Draw(_tempSprite);
-            }
+                    var c = _tempSprite.Color;
+                    _tempSprite.Color = new Color(c.R, c.G, c.B, 128);
+                    mapViewer.Draw(_tempSprite);
+                }
         }
 
         private void mapViewer_MouseDown(object sender, MouseEventArgs e)

--- a/EGMapEditor/MapEditor.Designer.cs
+++ b/EGMapEditor/MapEditor.Designer.cs
@@ -60,7 +60,7 @@
             this.menuStrip1.Location = new System.Drawing.Point(0, 0);
             this.menuStrip1.Name = "menuStrip1";
             this.menuStrip1.Padding = new System.Windows.Forms.Padding(8, 2, 0, 2);
-            this.menuStrip1.Size = new System.Drawing.Size(1545, 28);
+            this.menuStrip1.Size = new System.Drawing.Size(782, 28);
             this.menuStrip1.TabIndex = 0;
             this.menuStrip1.Text = "menuStrip1";
             // 
@@ -185,23 +185,22 @@
             this.dockPanel.Location = new System.Drawing.Point(0, 28);
             this.dockPanel.Margin = new System.Windows.Forms.Padding(3, 2, 3, 2);
             this.dockPanel.Name = "dockPanel";
-            this.dockPanel.Size = new System.Drawing.Size(1545, 789);
+            this.dockPanel.Size = new System.Drawing.Size(782, 525);
             this.dockPanel.TabIndex = 15;
             // 
             // MapEditor
             // 
             this.AutoScaleDimensions = new System.Drawing.SizeF(8F, 16F);
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
-            this.ClientSize = new System.Drawing.Size(1545, 817);
+            this.ClientSize = new System.Drawing.Size(782, 553);
             this.Controls.Add(this.dockPanel);
             this.Controls.Add(this.menuStrip1);
             this.IsMdiContainer = true;
             this.MainMenuStrip = this.menuStrip1;
             this.Margin = new System.Windows.Forms.Padding(4);
-            this.MaximizeBox = false;
-            this.MinimizeBox = false;
             this.Name = "MapEditor";
             this.Text = "MapEditor";
+            this.WindowState = System.Windows.Forms.FormWindowState.Maximized;
             this.Shown += new System.EventHandler(this.MapEditor_Shown);
             this.Resize += new System.EventHandler(this.MapEditor_Resize);
             this.menuStrip1.ResumeLayout(false);

--- a/EGMapEditor/MapEditor.cs
+++ b/EGMapEditor/MapEditor.cs
@@ -84,6 +84,8 @@ namespace EGMapEditor
             SelectingArea = new List<SelectedTileArea>();
 
             LoadTilesets();
+
+            menuAddMap_Click(null, null);
         }
 
         public void OpenMap(Map m)

--- a/EGMapEditor/StartForm.Designer.cs
+++ b/EGMapEditor/StartForm.Designer.cs
@@ -40,10 +40,10 @@
             this.rdbtnOnline = new System.Windows.Forms.RadioButton();
             this.btnConnect = new System.Windows.Forms.Button();
             this.groupBox2 = new System.Windows.Forms.GroupBox();
-            this.rdbtnSSize1 = new System.Windows.Forms.RadioButton();
-            this.rdbtnSSize2 = new System.Windows.Forms.RadioButton();
-            this.rdbtnSSize3 = new System.Windows.Forms.RadioButton();
             this.rdbtnSSize4 = new System.Windows.Forms.RadioButton();
+            this.rdbtnSSize3 = new System.Windows.Forms.RadioButton();
+            this.rdbtnSSize2 = new System.Windows.Forms.RadioButton();
+            this.rdbtnSSize1 = new System.Windows.Forms.RadioButton();
             this.groupBox1.SuspendLayout();
             this.groupBox2.SuspendLayout();
             this.SuspendLayout();
@@ -52,9 +52,10 @@
             // 
             this.btnEnter.DialogResult = System.Windows.Forms.DialogResult.OK;
             this.btnEnter.Enabled = false;
-            this.btnEnter.Location = new System.Drawing.Point(416, 179);
+            this.btnEnter.Location = new System.Drawing.Point(555, 220);
+            this.btnEnter.Margin = new System.Windows.Forms.Padding(4, 4, 4, 4);
             this.btnEnter.Name = "btnEnter";
-            this.btnEnter.Size = new System.Drawing.Size(94, 32);
+            this.btnEnter.Size = new System.Drawing.Size(125, 39);
             this.btnEnter.TabIndex = 0;
             this.btnEnter.Text = "Enter";
             this.btnEnter.UseVisualStyleBackColor = true;
@@ -70,67 +71,76 @@
             this.groupBox1.Controls.Add(this.txtIp);
             this.groupBox1.Controls.Add(this.rdbtnOffline);
             this.groupBox1.Controls.Add(this.rdbtnOnline);
-            this.groupBox1.Location = new System.Drawing.Point(12, 12);
+            this.groupBox1.Location = new System.Drawing.Point(16, 15);
+            this.groupBox1.Margin = new System.Windows.Forms.Padding(4, 4, 4, 4);
             this.groupBox1.Name = "groupBox1";
-            this.groupBox1.Size = new System.Drawing.Size(298, 199);
+            this.groupBox1.Padding = new System.Windows.Forms.Padding(4, 4, 4, 4);
+            this.groupBox1.Size = new System.Drawing.Size(397, 245);
             this.groupBox1.TabIndex = 1;
             this.groupBox1.TabStop = false;
             this.groupBox1.Text = "Connection Type";
             // 
             // txtPass
             // 
-            this.txtPass.Location = new System.Drawing.Point(78, 120);
+            this.txtPass.Location = new System.Drawing.Point(104, 148);
+            this.txtPass.Margin = new System.Windows.Forms.Padding(4, 4, 4, 4);
             this.txtPass.Name = "txtPass";
-            this.txtPass.Size = new System.Drawing.Size(204, 20);
+            this.txtPass.Size = new System.Drawing.Size(271, 22);
             this.txtPass.TabIndex = 7;
             // 
             // label3
             // 
             this.label3.AutoSize = true;
-            this.label3.Location = new System.Drawing.Point(17, 123);
+            this.label3.Location = new System.Drawing.Point(23, 151);
+            this.label3.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
             this.label3.Name = "label3";
-            this.label3.Size = new System.Drawing.Size(56, 13);
+            this.label3.Size = new System.Drawing.Size(73, 17);
             this.label3.TabIndex = 6;
             this.label3.Text = "Password:";
             // 
             // label2
             // 
             this.label2.AutoSize = true;
-            this.label2.Location = new System.Drawing.Point(15, 97);
+            this.label2.Location = new System.Drawing.Point(20, 119);
+            this.label2.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
             this.label2.Name = "label2";
-            this.label2.Size = new System.Drawing.Size(58, 13);
+            this.label2.Size = new System.Drawing.Size(77, 17);
             this.label2.TabIndex = 5;
             this.label2.Text = "Username:";
             // 
             // label1
             // 
             this.label1.AutoSize = true;
-            this.label1.Location = new System.Drawing.Point(12, 71);
+            this.label1.Location = new System.Drawing.Point(16, 87);
+            this.label1.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
             this.label1.Name = "label1";
-            this.label1.Size = new System.Drawing.Size(61, 13);
+            this.label1.Size = new System.Drawing.Size(80, 17);
             this.label1.TabIndex = 4;
             this.label1.Text = "IP Address:";
             // 
             // txtUser
             // 
-            this.txtUser.Location = new System.Drawing.Point(78, 94);
+            this.txtUser.Location = new System.Drawing.Point(104, 116);
+            this.txtUser.Margin = new System.Windows.Forms.Padding(4, 4, 4, 4);
             this.txtUser.Name = "txtUser";
-            this.txtUser.Size = new System.Drawing.Size(204, 20);
+            this.txtUser.Size = new System.Drawing.Size(271, 22);
             this.txtUser.TabIndex = 3;
             // 
             // txtIp
             // 
-            this.txtIp.Location = new System.Drawing.Point(78, 68);
+            this.txtIp.Location = new System.Drawing.Point(104, 84);
+            this.txtIp.Margin = new System.Windows.Forms.Padding(4, 4, 4, 4);
             this.txtIp.Name = "txtIp";
-            this.txtIp.Size = new System.Drawing.Size(204, 20);
+            this.txtIp.Size = new System.Drawing.Size(271, 22);
             this.txtIp.TabIndex = 2;
             // 
             // rdbtnOffline
             // 
             this.rdbtnOffline.AutoSize = true;
-            this.rdbtnOffline.Location = new System.Drawing.Point(18, 157);
+            this.rdbtnOffline.Location = new System.Drawing.Point(24, 193);
+            this.rdbtnOffline.Margin = new System.Windows.Forms.Padding(4, 4, 4, 4);
             this.rdbtnOffline.Name = "rdbtnOffline";
-            this.rdbtnOffline.Size = new System.Drawing.Size(55, 17);
+            this.rdbtnOffline.Size = new System.Drawing.Size(70, 21);
             this.rdbtnOffline.TabIndex = 1;
             this.rdbtnOffline.Text = "Offline";
             this.rdbtnOffline.UseVisualStyleBackColor = true;
@@ -140,9 +150,10 @@
             // 
             this.rdbtnOnline.AutoSize = true;
             this.rdbtnOnline.Checked = true;
-            this.rdbtnOnline.Location = new System.Drawing.Point(18, 30);
+            this.rdbtnOnline.Location = new System.Drawing.Point(24, 37);
+            this.rdbtnOnline.Margin = new System.Windows.Forms.Padding(4, 4, 4, 4);
             this.rdbtnOnline.Name = "rdbtnOnline";
-            this.rdbtnOnline.Size = new System.Drawing.Size(55, 17);
+            this.rdbtnOnline.Size = new System.Drawing.Size(70, 21);
             this.rdbtnOnline.TabIndex = 0;
             this.rdbtnOnline.TabStop = true;
             this.rdbtnOnline.Text = "Online";
@@ -151,9 +162,10 @@
             // 
             // btnConnect
             // 
-            this.btnConnect.Location = new System.Drawing.Point(316, 179);
+            this.btnConnect.Location = new System.Drawing.Point(421, 220);
+            this.btnConnect.Margin = new System.Windows.Forms.Padding(4, 4, 4, 4);
             this.btnConnect.Name = "btnConnect";
-            this.btnConnect.Size = new System.Drawing.Size(94, 32);
+            this.btnConnect.Size = new System.Drawing.Size(125, 39);
             this.btnConnect.TabIndex = 2;
             this.btnConnect.Text = "Connect";
             this.btnConnect.UseVisualStyleBackColor = true;
@@ -164,64 +176,72 @@
             this.groupBox2.Controls.Add(this.rdbtnSSize3);
             this.groupBox2.Controls.Add(this.rdbtnSSize2);
             this.groupBox2.Controls.Add(this.rdbtnSSize1);
-            this.groupBox2.Location = new System.Drawing.Point(316, 12);
+            this.groupBox2.Location = new System.Drawing.Point(421, 15);
+            this.groupBox2.Margin = new System.Windows.Forms.Padding(4, 4, 4, 4);
             this.groupBox2.Name = "groupBox2";
-            this.groupBox2.Size = new System.Drawing.Size(194, 161);
+            this.groupBox2.Padding = new System.Windows.Forms.Padding(4, 4, 4, 4);
+            this.groupBox2.Size = new System.Drawing.Size(259, 198);
             this.groupBox2.TabIndex = 3;
             this.groupBox2.TabStop = false;
             this.groupBox2.Text = "Screen Size";
+            this.groupBox2.Visible = false;
             // 
-            // rdbtnSSize1
+            // rdbtnSSize4
             // 
-            this.rdbtnSSize1.AutoSize = true;
-            this.rdbtnSSize1.Location = new System.Drawing.Point(19, 30);
-            this.rdbtnSSize1.Name = "rdbtnSSize1";
-            this.rdbtnSSize1.Size = new System.Drawing.Size(66, 17);
-            this.rdbtnSSize1.TabIndex = 0;
-            this.rdbtnSSize1.Text = "800x600";
-            this.rdbtnSSize1.UseVisualStyleBackColor = true;
+            this.rdbtnSSize4.AutoSize = true;
+            this.rdbtnSSize4.Location = new System.Drawing.Point(25, 122);
+            this.rdbtnSSize4.Margin = new System.Windows.Forms.Padding(4, 4, 4, 4);
+            this.rdbtnSSize4.Name = "rdbtnSSize4";
+            this.rdbtnSSize4.Size = new System.Drawing.Size(99, 21);
+            this.rdbtnSSize4.TabIndex = 4;
+            this.rdbtnSSize4.Text = "1920x1080";
+            this.rdbtnSSize4.UseVisualStyleBackColor = true;
+            // 
+            // rdbtnSSize3
+            // 
+            this.rdbtnSSize3.AutoSize = true;
+            this.rdbtnSSize3.Location = new System.Drawing.Point(25, 94);
+            this.rdbtnSSize3.Margin = new System.Windows.Forms.Padding(4, 4, 4, 4);
+            this.rdbtnSSize3.Name = "rdbtnSSize3";
+            this.rdbtnSSize3.Size = new System.Drawing.Size(91, 21);
+            this.rdbtnSSize3.TabIndex = 2;
+            this.rdbtnSSize3.Text = "1366x768";
+            this.rdbtnSSize3.UseVisualStyleBackColor = true;
             // 
             // rdbtnSSize2
             // 
             this.rdbtnSSize2.AutoSize = true;
             this.rdbtnSSize2.Checked = true;
-            this.rdbtnSSize2.Location = new System.Drawing.Point(19, 53);
+            this.rdbtnSSize2.Location = new System.Drawing.Point(25, 65);
+            this.rdbtnSSize2.Margin = new System.Windows.Forms.Padding(4, 4, 4, 4);
             this.rdbtnSSize2.Name = "rdbtnSSize2";
-            this.rdbtnSSize2.Size = new System.Drawing.Size(72, 17);
+            this.rdbtnSSize2.Size = new System.Drawing.Size(91, 21);
             this.rdbtnSSize2.TabIndex = 1;
             this.rdbtnSSize2.TabStop = true;
             this.rdbtnSSize2.Text = "1024x768";
             this.rdbtnSSize2.UseVisualStyleBackColor = true;
             // 
-            // rdbtnSSize3
+            // rdbtnSSize1
             // 
-            this.rdbtnSSize3.AutoSize = true;
-            this.rdbtnSSize3.Location = new System.Drawing.Point(19, 76);
-            this.rdbtnSSize3.Name = "rdbtnSSize3";
-            this.rdbtnSSize3.Size = new System.Drawing.Size(72, 17);
-            this.rdbtnSSize3.TabIndex = 2;
-            this.rdbtnSSize3.Text = "1366x768";
-            this.rdbtnSSize3.UseVisualStyleBackColor = true;
-            // 
-            // rdbtnSSize4
-            // 
-            this.rdbtnSSize4.AutoSize = true;
-            this.rdbtnSSize4.Location = new System.Drawing.Point(19, 99);
-            this.rdbtnSSize4.Name = "rdbtnSSize4";
-            this.rdbtnSSize4.Size = new System.Drawing.Size(78, 17);
-            this.rdbtnSSize4.TabIndex = 4;
-            this.rdbtnSSize4.Text = "1920x1080";
-            this.rdbtnSSize4.UseVisualStyleBackColor = true;
+            this.rdbtnSSize1.AutoSize = true;
+            this.rdbtnSSize1.Location = new System.Drawing.Point(25, 37);
+            this.rdbtnSSize1.Margin = new System.Windows.Forms.Padding(4, 4, 4, 4);
+            this.rdbtnSSize1.Name = "rdbtnSSize1";
+            this.rdbtnSSize1.Size = new System.Drawing.Size(83, 21);
+            this.rdbtnSSize1.TabIndex = 0;
+            this.rdbtnSSize1.Text = "800x600";
+            this.rdbtnSSize1.UseVisualStyleBackColor = true;
             // 
             // StartForm
             // 
-            this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
+            this.AutoScaleDimensions = new System.Drawing.SizeF(8F, 16F);
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
-            this.ClientSize = new System.Drawing.Size(522, 222);
+            this.ClientSize = new System.Drawing.Size(696, 273);
             this.Controls.Add(this.groupBox2);
             this.Controls.Add(this.btnConnect);
             this.Controls.Add(this.groupBox1);
             this.Controls.Add(this.btnEnter);
+            this.Margin = new System.Windows.Forms.Padding(4, 4, 4, 4);
             this.Name = "StartForm";
             this.Text = "EG Map Editor";
             this.FormClosing += new System.Windows.Forms.FormClosingEventHandler(this.StartForm_FormClosing);

--- a/EGMapEditor/StartForm.cs
+++ b/EGMapEditor/StartForm.cs
@@ -11,6 +11,7 @@ namespace EGMapEditor
         public StartForm()
         {
             InitializeComponent();
+            rdbtnOffline.Checked = true;
         }
 
         private void rdbtnOnline_CheckedChanged(object sender, EventArgs e)

--- a/EGMapEditor/StartForm.resx
+++ b/EGMapEditor/StartForm.resx
@@ -59,7 +59,7 @@
             : using a System.ComponentModel.TypeConverter
             : and then encoded with base64 encoding.
     -->
-  <xsd:schema Id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
     <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
     <xsd:element name="root" msdata:IsDataSet="true">
       <xsd:complexType>

--- a/EGMapEditor/packages.config
+++ b/EGMapEditor/packages.config
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package Id="ArchaicSoft.DockPanel" version="1.0.0" targetFramework="net452" />
+  <package Id="ArchaicSoft.DockPanel" version="1.1.2" targetFramework="net452" />
   <package Id="SFML.Net.Portable" version="1.2.1" targetFramework="net452" />
 </packages>


### PR DESCRIPTION
Map form will auto open in fullscreen, re-enabled minimize/maximize buttons, hid the screensize stuff and since still in dev stage, auto sets the offline value(Can be reversed back to having connection first by removing one line) changed the draw hover so it doesnt appear it might place tiledata on 2+ maps at once when editing maps side by side, updated package target for latest dockpanels, and the map editor starts up with a blank map by default for convenience.
